### PR TITLE
RCCA-17200: Sync: Fix page by page query in sync, leading to duplicated entries

### DIFF
--- a/cmd/devcli/commands/ddb/ddb.go
+++ b/cmd/devcli/commands/ddb/ddb.go
@@ -4,6 +4,6 @@ import "github.com/urfave/cli/v2"
 
 var DDBCommand = cli.Command{
 	Name:        "ddb",
-	Subcommands: []*cli.Command{&getUsersCommand, &getGroupsCommand},
+	Subcommands: []*cli.Command{&getUsersCommand, &getGroupsCommand, &deleteDuplicatedUsersCommand},
 	Action:      cli.ShowSubcommandHelp,
 }

--- a/cmd/devcli/commands/ddb/ddb.go
+++ b/cmd/devcli/commands/ddb/ddb.go
@@ -1,0 +1,9 @@
+package ddb
+
+import "github.com/urfave/cli/v2"
+
+var DDBCommand = cli.Command{
+	Name:        "ddb",
+	Subcommands: []*cli.Command{&getUsersCommand, &getGroupsCommand},
+	Action:      cli.ShowSubcommandHelp,
+}

--- a/cmd/devcli/commands/ddb/delete_duplicated_users.go
+++ b/cmd/devcli/commands/ddb/delete_duplicated_users.go
@@ -5,13 +5,36 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/urfave/cli/v2"
 
 	"github.com/common-fate/common-fate/pkg/identity"
 	"github.com/common-fate/common-fate/pkg/storage"
 	"github.com/common-fate/common-fate/pkg/storage/ddbhelpers"
+	"github.com/common-fate/common-fate/pkg/storage/keys"
 	"github.com/common-fate/ddb"
 )
+
+// Needed to filter by duplicates. Not needed in normal operations
+type ListUsersForEmail struct {
+	Result []identity.User `ddb:"result"`
+	Email  string
+}
+
+func (l *ListUsersForEmail) BuildQuery() (*dynamodb.QueryInput, error) {
+
+	qi := dynamodb.QueryInput{
+		IndexName:              aws.String(keys.IndexNames.GSI2),
+		KeyConditionExpression: aws.String("GSI2PK = :pk2 and GSI2SK = :sk2"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk2": &types.AttributeValueMemberS{Value: keys.Users.GSI2PK},
+			":sk2": &types.AttributeValueMemberS{Value: keys.Users.GSI2SK(string(l.Email))},
+		},
+	}
+	return &qi, nil
+}
 
 func findDuplicates(users []identity.User, maxDups int) []identity.User {
 	toDelete := []identity.User{}
@@ -37,21 +60,21 @@ func findDuplicates(users []identity.User, maxDups int) []identity.User {
 
 var deleteDuplicatedUsersCommand = cli.Command{
 	Name: "delete-duplicated-users",
-	Description: `
-		Find any duplicated users in the Dynamodb DB.
+	Description: `Find any duplicated users in the Dynamodb DB.
 
-		This command fixes the issue of duplicated users added during sync due
-		the lack of pagination querying dynamodb.
+This command fixes the issue of duplicated users added during sync due
+the lack of pagination querying dynamodb.
 
-		It will list all users in dynamodb, identifying those with a duplicated
-		email, and keeping the one with the newest creation date.
+It will list all users in dynamodb, identifying those with a duplicated
+email, and keeping the one with the newest creation date.
 
-		Runs by default in dry-run mode, or allows to delete them from dynamodb.
+Runs by default in dry-run mode, or allows to delete them from dynamodb.
 	`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{Name: "name", Usage: "The name of the table", Required: true},
 		// TODO set the region? now I user AWS_REGION=...
 		// &cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "AWS region to provision the table into"},
+		&cli.StringFlag{Name: "email", Aliases: []string{"r"}, Usage: "Search duplicates only for given email"},
 		&cli.IntFlag{Name: "limit", Usage: "Total limit of elements to stop pagination. Set 0 for unlimited.", Value: 0},
 		&cli.BoolFlag{Name: "pagination", Usage: "Process pagination in query", Value: true},
 		&cli.BoolFlag{Name: "dry-run", Usage: "Set to false to actually delete the users. Default true", Value: true},
@@ -61,6 +84,7 @@ var deleteDuplicatedUsersCommand = cli.Command{
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
 		tableName := c.String("name")
+		email := c.String("email")
 		limit := c.Int("limit")
 		pagination := c.Bool("pagination")
 		dryRun := c.Bool("dry-run")
@@ -71,7 +95,12 @@ var deleteDuplicatedUsersCommand = cli.Command{
 			return err
 		}
 
-		uq := &storage.ListUsers{}
+		var uq ddb.QueryBuilder
+		if email == "" {
+			uq = &storage.ListUsers{}
+		} else {
+			uq = &ListUsersForEmail{Email: email}
+		}
 
 		users := []identity.User{}
 		err = ddbhelpers.QueryPages(ctx, db, uq,
@@ -80,6 +109,8 @@ var deleteDuplicatedUsersCommand = cli.Command{
 				case *storage.ListUsersForStatus:
 					users = append(users, qb.Result...)
 				case *storage.ListUsers:
+					users = append(users, qb.Result...)
+				case *ListUsersForEmail:
 					users = append(users, qb.Result...)
 				default:
 					panic("Unknown type for Query Buidler")

--- a/cmd/devcli/commands/ddb/delete_duplicated_users.go
+++ b/cmd/devcli/commands/ddb/delete_duplicated_users.go
@@ -1,0 +1,126 @@
+package ddb
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/common-fate/common-fate/pkg/identity"
+	"github.com/common-fate/common-fate/pkg/storage"
+	"github.com/common-fate/common-fate/pkg/storage/ddbhelpers"
+	"github.com/common-fate/ddb"
+)
+
+func findDuplicates(users []identity.User, maxDups int) []identity.User {
+	toDelete := []identity.User{}
+	userMap := map[string]identity.User{}
+
+	for _, u := range users {
+		if u2, ok := userMap[u.Email]; ok {
+			if u2.CreatedAt.Before(u.CreatedAt) {
+				toDelete = append(toDelete, u)
+			} else {
+				userMap[u.Email] = u
+				toDelete = append(toDelete, u2)
+			}
+		} else {
+			userMap[u.Email] = u
+		}
+		if maxDups > 0 && len(toDelete) >= maxDups {
+			break
+		}
+	}
+	return toDelete
+}
+
+var deleteDuplicatedUsersCommand = cli.Command{
+	Name: "delete-duplicated-users",
+	Description: `
+		Find any duplicated users in the Dynamodb DB.
+
+		This command fixes the issue of duplicated users added during sync due
+		the lack of pagination querying dynamodb.
+
+		It will list all users in dynamodb, identifying those with a duplicated
+		email, and keeping the one with the newest creation date.
+
+		Runs by default in dry-run mode, or allows to delete them from dynamodb.
+	`,
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "name", Usage: "The name of the table", Required: true},
+		// TODO set the region? now I user AWS_REGION=...
+		// &cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "AWS region to provision the table into"},
+		&cli.IntFlag{Name: "limit", Usage: "Total limit of elements to stop pagination. Set 0 for unlimited.", Value: 0},
+		&cli.BoolFlag{Name: "pagination", Usage: "Process pagination in query", Value: true},
+		&cli.BoolFlag{Name: "dry-run", Usage: "Set to false to actually delete the users. Default true", Value: true},
+		&cli.IntFlag{Name: "max-dups", Usage: "Only delete a max of given duplicates", Value: 0},
+	},
+
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+		tableName := c.String("name")
+		limit := c.Int("limit")
+		pagination := c.Bool("pagination")
+		dryRun := c.Bool("dry-run")
+		maxDups := c.Int("max-dups")
+
+		db, err := ddb.New(ctx, tableName)
+		if err != nil {
+			return err
+		}
+
+		uq := &storage.ListUsers{}
+
+		users := []identity.User{}
+		err = ddbhelpers.QueryPages(ctx, db, uq,
+			func(pageResult *ddb.QueryResult, pageQueryBuilder ddb.QueryBuilder, lastPage bool) bool {
+				switch qb := pageQueryBuilder.(type) {
+				case *storage.ListUsersForStatus:
+					users = append(users, qb.Result...)
+				case *storage.ListUsers:
+					users = append(users, qb.Result...)
+				default:
+					panic("Unknown type for Query Buidler")
+				}
+				if limit > 0 && len(users) >= limit {
+					return false
+				}
+				return pagination
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(os.Stderr, "Got %d users\n", len(users))
+		fmt.Fprintln(os.Stderr, "Calculating duplicates...")
+
+		duplicatedUsers := findDuplicates(users, maxDups)
+
+		b, err := json.MarshalIndent(duplicatedUsers, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+
+		fmt.Fprintf(os.Stderr, "Found %d duplicated\n", len(duplicatedUsers))
+
+		if !dryRun {
+			fmt.Fprintln(os.Stderr, "Deleting duplicates...")
+			entriesToDelete := make([]ddb.Keyer, len(duplicatedUsers))
+			for i, u := range duplicatedUsers {
+				entriesToDelete[i] = &u
+			}
+			err = db.DeleteBatch(ctx, entriesToDelete...)
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintln(os.Stderr, "WARNING: Dry-run mode, skipping deletion...")
+		}
+
+		return nil
+	},
+}

--- a/cmd/devcli/commands/ddb/get_groups.go
+++ b/cmd/devcli/commands/ddb/get_groups.go
@@ -53,7 +53,7 @@ var getGroupsCommand = cli.Command{
 			return err
 		}
 
-		b, err := json.Marshal(gq.Result)
+		b, err := json.MarshalIndent(gq.Result, "", "  ")
 		if err != nil {
 			return err
 		}

--- a/cmd/devcli/commands/ddb/get_groups.go
+++ b/cmd/devcli/commands/ddb/get_groups.go
@@ -1,0 +1,64 @@
+package ddb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/common-fate/common-fate/pkg/identity"
+	"github.com/common-fate/common-fate/pkg/storage"
+	"github.com/common-fate/common-fate/pkg/storage/ddbhelpers"
+	"github.com/common-fate/ddb"
+)
+
+var getGroupsCommand = cli.Command{
+	Name: "get-groups",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "The name of the table", Required: true},
+		// TODO set the region? now I user AWS_REGION=...
+		// &cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "AWS region to provision the table into"},
+		&cli.IntFlag{Name: "limit", Aliases: []string{"l"}, Usage: "Total limit of elements to stop pagination. Set 0 for unlimited.", Value: 0},
+		&cli.BoolFlag{Name: "pagination", Aliases: []string{"p"}, Usage: "Process pagination in query", Value: true},
+	},
+
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+		tableName := c.String("name")
+		limit := c.Int("limit")
+		pagination := c.Bool("pagination")
+
+		db, err := ddb.New(ctx, tableName)
+		if err != nil {
+			return err
+		}
+
+		gq := &storage.ListGroups{}
+
+		var groups []identity.Group
+		err = ddbhelpers.QueryPages(ctx, db, gq,
+			func(pageResult *ddb.QueryResult, pageQueryBuilder ddb.QueryBuilder, lastPage bool) bool {
+				if qb, ok := pageQueryBuilder.(*storage.ListGroups); ok {
+					groups = append(groups, qb.Result...)
+				} else {
+					panic("Unknown type for QueryBuilder")
+				}
+				if limit > 0 && len(groups) >= limit {
+					return false
+				}
+				return pagination
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.Marshal(gq.Result)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+
+		return nil
+	},
+}

--- a/cmd/devcli/commands/ddb/get_users.go
+++ b/cmd/devcli/commands/ddb/get_users.go
@@ -1,0 +1,84 @@
+package ddb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/common-fate/common-fate/pkg/identity"
+	"github.com/common-fate/common-fate/pkg/storage"
+	"github.com/common-fate/common-fate/pkg/storage/ddbhelpers"
+	"github.com/common-fate/common-fate/pkg/types"
+	"github.com/common-fate/ddb"
+)
+
+var getUsersCommand = cli.Command{
+	Name: "get-users",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "The name of the table", Required: true},
+		// TODO set the region? now I user AWS_REGION=...
+		// &cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "AWS region to provision the table into"},
+		&cli.StringFlag{Name: "status", Aliases: []string{"s"}, Usage: "Status: active|deactived|all", Value: "active"},
+		&cli.IntFlag{Name: "limit", Aliases: []string{"l"}, Usage: "Total limit of elements to stop pagination. Set 0 for unlimited.", Value: 0},
+		&cli.BoolFlag{Name: "pagination", Aliases: []string{"p"}, Usage: "Process pagination in query", Value: true},
+	},
+
+	Action: func(c *cli.Context) error {
+		ctx := c.Context
+		tableName := c.String("name")
+		status := c.String("status")
+		limit := c.Int("limit")
+		pagination := c.Bool("pagination")
+
+		db, err := ddb.New(ctx, tableName)
+		if err != nil {
+			return err
+		}
+
+		var uq ddb.QueryBuilder
+		switch status {
+		case "active":
+			uq = &storage.ListUsersForStatus{
+				Status: types.IdpStatusACTIVE,
+			}
+		case "archived":
+			uq = &storage.ListUsersForStatus{
+				Status: types.IdpStatusACTIVE,
+			}
+		case "all":
+			uq = &storage.ListUsers{}
+		default:
+			return fmt.Errorf("Unknown status label %s", status)
+		}
+
+		users := []identity.User{}
+		err = ddbhelpers.QueryPages(ctx, db, uq,
+			func(pageResult *ddb.QueryResult, pageQueryBuilder ddb.QueryBuilder, lastPage bool) bool {
+				switch qb := pageQueryBuilder.(type) {
+				case *storage.ListUsersForStatus:
+					users = append(users, qb.Result...)
+				case *storage.ListUsers:
+					users = append(users, qb.Result...)
+				default:
+					panic("Unknown type for Query Buidler")
+				}
+				if limit > 0 && len(users) >= limit {
+					return false
+				}
+				return pagination
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.MarshalIndent(users, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+
+		return nil
+	},
+}

--- a/cmd/devcli/commands/ddb/get_users.go
+++ b/cmd/devcli/commands/ddb/get_users.go
@@ -19,7 +19,8 @@ var getUsersCommand = cli.Command{
 		&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "The name of the table", Required: true},
 		// TODO set the region? now I user AWS_REGION=...
 		// &cli.StringFlag{Name: "region", Aliases: []string{"r"}, Usage: "AWS region to provision the table into"},
-		&cli.StringFlag{Name: "status", Aliases: []string{"s"}, Usage: "Status: active|deactived|all", Value: "active"},
+		&cli.StringFlag{Name: "email", Aliases: []string{"r"}, Usage: "Search duplicates only for given email"},
+		&cli.StringFlag{Name: "status", Aliases: []string{"s"}, Usage: "Status: active|deactived|all", Value: ""},
 		&cli.IntFlag{Name: "limit", Aliases: []string{"l"}, Usage: "Total limit of elements to stop pagination. Set 0 for unlimited.", Value: 0},
 		&cli.BoolFlag{Name: "pagination", Aliases: []string{"p"}, Usage: "Process pagination in query", Value: true},
 	},
@@ -28,6 +29,7 @@ var getUsersCommand = cli.Command{
 		ctx := c.Context
 		tableName := c.String("name")
 		status := c.String("status")
+		email := c.String("email")
 		limit := c.Int("limit")
 		pagination := c.Bool("pagination")
 
@@ -37,19 +39,26 @@ var getUsersCommand = cli.Command{
 		}
 
 		var uq ddb.QueryBuilder
-		switch status {
-		case "active":
-			uq = &storage.ListUsersForStatus{
-				Status: types.IdpStatusACTIVE,
+		if email != "" {
+			if status != "" && status != "all" {
+				return fmt.Errorf("Cannot specify email=%s and status=%s at the same time", email, status)
 			}
-		case "archived":
-			uq = &storage.ListUsersForStatus{
-				Status: types.IdpStatusACTIVE,
+			uq = &ListUsersForEmail{Email: email}
+		} else {
+			switch status {
+			case "", "all":
+				uq = &storage.ListUsers{}
+			case "active":
+				uq = &storage.ListUsersForStatus{
+					Status: types.IdpStatusACTIVE,
+				}
+			case "archived":
+				uq = &storage.ListUsersForStatus{
+					Status: types.IdpStatusARCHIVED,
+				}
+			default:
+				return fmt.Errorf("Unknown status label %s", status)
 			}
-		case "all":
-			uq = &storage.ListUsers{}
-		default:
-			return fmt.Errorf("Unknown status label %s", status)
 		}
 
 		users := []identity.User{}
@@ -59,6 +68,8 @@ var getUsersCommand = cli.Command{
 				case *storage.ListUsersForStatus:
 					users = append(users, qb.Result...)
 				case *storage.ListUsers:
+					users = append(users, qb.Result...)
+				case *ListUsersForEmail:
 					users = append(users, qb.Result...)
 				default:
 					panic("Unknown type for Query Buidler")

--- a/cmd/devcli/commands/ddb/utils.go
+++ b/cmd/devcli/commands/ddb/utils.go
@@ -1,0 +1,44 @@
+package ddb
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/common-fate/common-fate/pkg/identity"
+	"github.com/common-fate/common-fate/pkg/storage/keys"
+	"github.com/common-fate/ddb"
+)
+
+// Needed to be able to delete without duplicates
+type UserBaseKeyOnly struct {
+	ID string
+}
+
+func (u *UserBaseKeyOnly) DDBKeys() (ddb.Keys, error) {
+	keys := ddb.Keys{
+		PK: keys.Users.PK1,
+		SK: keys.Users.SK1(u.ID),
+	}
+
+	return keys, nil
+}
+
+// Needed to filter by duplicates. Not needed in normal operations
+type ListUsersForEmail struct {
+	Result []identity.User `ddb:"result"`
+	Email  string
+}
+
+func (l *ListUsersForEmail) BuildQuery() (*dynamodb.QueryInput, error) {
+
+	qi := dynamodb.QueryInput{
+		IndexName:              aws.String(keys.IndexNames.GSI2),
+		KeyConditionExpression: aws.String("GSI2PK = :pk2 and GSI2SK = :sk2"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk2": &types.AttributeValueMemberS{Value: keys.Users.GSI2PK},
+			":sk2": &types.AttributeValueMemberS{Value: keys.Users.GSI2SK(string(l.Email))},
+		},
+	}
+	return &qi, nil
+}

--- a/cmd/devcli/main.go
+++ b/cmd/devcli/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/common-fate/common-fate/cmd/devcli/commands/cache"
 	"github.com/common-fate/common-fate/cmd/devcli/commands/db"
+	"github.com/common-fate/common-fate/cmd/devcli/commands/ddb"
 	"github.com/common-fate/common-fate/cmd/devcli/commands/events"
 	"github.com/common-fate/common-fate/cmd/devcli/commands/grants"
 	"github.com/common-fate/common-fate/cmd/devcli/commands/groups"
@@ -27,6 +28,7 @@ func main() {
 		Commands: []*cli.Command{
 			&groups.GroupsCommand,
 			&db.DBCommand,
+			&ddb.DDBCommand,
 			&events.EventsCommand,
 			&slack.SlackCommand,
 			&cache.CacheCommand,

--- a/pkg/storage/ddbhelpers/query_pages.go
+++ b/pkg/storage/ddbhelpers/query_pages.go
@@ -1,0 +1,30 @@
+package ddbhelpers
+
+import (
+	"context"
+
+	"github.com/common-fate/ddb"
+)
+
+func QueryPages(
+	ctx context.Context, c ddb.Storage, qb ddb.QueryBuilder,
+	f func(pageResult *ddb.QueryResult, pageQueryBuilder ddb.QueryBuilder, lastPage bool) bool,
+	opts ...func(*ddb.QueryOpts),
+) error {
+	var nextPage string
+	for {
+		result, err := c.Query(ctx, qb, ddb.Page(nextPage))
+		if err != nil {
+			return err
+		}
+		lastPage := result.NextPage == ""
+		if !f(result, qb, lastPage) {
+			break
+		}
+		if lastPage {
+			break
+		}
+		nextPage = result.NextPage
+	}
+	return nil
+}


### PR DESCRIPTION
### What changed?

In this PR we:

 * Modify the DynamodDB queries in the sync lambda to iterate
   the query page by page.

 * Provide commands in dev-cli tool to allow get users and groups

 * Provide a command line tool to delete duplicated users in dynamodb


### Why?

Currently sync process does not iterate the paginated responses from
dynamodb, reading around 2700 users maximum, Active and Archived.

This can lead to a bug in the sync proces, where it will create
duplicated entries in DB in each sync, with new IDs, and updating
the groups to point to these users. In the meantime, the users
might still have access to Glide, but not be members of the groups.

In detail:
 1. Sync reads the first 2700 user entries in dynamodb, missing any other
 2. Sync reads all IDP users
 3. Sync tries to find if the user is already in DB. As the query
    was partial, it will be considered a new user.
 4. A new user ID is created, with a new PK/SK
 5. Groups are updated to point to the new ID

Observed behaviour:
 - A random set of users would not have access to any rule based
   on groups. But can be added individually.
 - DynamoDB table grows infinitely in each sync

How to trigger the issue:
 - Try to get more than >2700 users in the dynamodb, for instance
   by syncing >2700 users. Users can be later deactivated.

### Workaround and remediation

In our case our DB grew to >650k users. We were forced to create
a cli tool to cleanup dynamodb.


### How did you test it?

Tested manually. Pending implement some unit testing mocking
the ddb library.

Cli tool tested manually.

### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs